### PR TITLE
Update lounge MU flag

### DIFF
--- a/core/profiles.py
+++ b/core/profiles.py
@@ -95,6 +95,7 @@ class lounge_meta:
     pretty_name = "The Lounge"
     baseurl = "/irc"
     runas = "lounge"
+    multiuser = True
     
 class mango_meta:
     name = "mango"


### PR DESCRIPTION
It already is MU in main repo and new users get automatically added with passwords and all, not sure why it was not set to to not be MU