### PR TITLE
Temporary pin itsdangerous version to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flask-limiter
 eventlet
 requests
 dnspython==1.16.0; python_version == "3.5"
+itsdangerous==2.0.0


### PR DESCRIPTION
This is a temporary fix for the bug https://github.com/swizzin/swizzin/issues/837

itsdangerous has depracated the JWS support in version 2.1.0 and is recommending moving to authlib:
https://itsdangerous.palletsprojects.com/en/2.0.x/jws/