### PR TITLE
Disk Info Applet - Add support to zfs filesystems

### DIFF
--- a/core/util.py
+++ b/core/util.py
@@ -56,6 +56,8 @@ def get_mounts():
                     continue
                 else:
                     mounts.append(fields[1])
+            if fields[2] == "zfs":
+                mounts.append(fields[1])
     with open("/etc/fstab") as fstab:
         for line in fstab:
             fields = line.strip().split()


### PR DESCRIPTION
zfs filesystems do not starts with /dev, which makes the get_mounts() function ignore it.
this patch adds support to zfs filesystem by checking the filesystem type.