### PR TITLE
Fixing free disk size bug caused by Docker volume

### DIFF
--- a/core/util.py
+++ b/core/util.py
@@ -52,7 +52,7 @@ def get_mounts():
         for line in mount:
             fields = line.strip().split()
             if fields[0].startswith("/dev"):
-                if ("boot" in fields[1]) or ("fuse" in fields) or ("/snap/" in fields[1]) or ("/loop" in fields[0]):
+                if ("boot" in fields[1]) or ("fuse" in fields) or ("/snap/" in fields[1]) or ("/loop" in fields[0]) or ("/docker" in fields[1]):
                     continue
                 else:
                     mounts.append(fields[1])


### PR DESCRIPTION
Bug appears when mounting docker volume with bind propagation. Example: https://i.vgy.me/Io7kTC.png

This commit removes the volume overlay showing up on the dashboard.