### PR TITLE
Update Network Info widget

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -18,3 +18,8 @@ class Config:
     FORMS_LOGIN = True
     NETWORK_TOTALS = False
     DISK_UNITS = "iec"
+
+    NETWORK_INFO_CUTOFF = "YYYY-MM-DD"
+    NETWORK_INFO_TOP = True
+    NETWORK_INFO_TOPSTATS = 5
+    NETWORK_INFO_TOTALS = True

--- a/core/util.py
+++ b/core/util.py
@@ -212,8 +212,11 @@ def systemctl(function, application):
         result = sp.run(('sudo', 'systemctl', function, application), stdout=sp.DEVNULL).returncode
     return result
 
-def vnstat_data(interface, mode):
-    vnstat = sp.run(('vnstat', '-i', interface, '--json', mode), stdout=sp.PIPE)
+def vnstat_data(interface, mode, begin=False):
+    if begin is not False:
+        vnstat = sp.run(('vnstat', '-i', interface, '-b', begin, "--json", mode), stdout=sp.PIPE)
+    else:
+        vnstat = sp.run(('vnstat', '-i', interface, '--json', mode), stdout=sp.PIPE)
     data = json.loads(vnstat.stdout.decode('utf-8'))
     #data = vnstat.stdout.decode('utf-8')
     return data

--- a/swizzin.py
+++ b/swizzin.py
@@ -335,12 +335,30 @@ def vnstat(user):
         tx =read_unit(t['tx'])
         total = read_unit(t['tx'] + t['rx'])
         timeline.append({"date": date, "rx": rx, "tx": tx, "total": total})
+
+    if app.config['NETWORK_INFO_TOP']:
+        if not app.config['NETWORK_INFO_CUTOFF'] or app.config['NETWORK_INFO_CUTOFF'] == "YYYY-MM-DD":
+            tops = vnstat_data(interface, "t")['interfaces'][0]['traffic'][qt]
+        else:
+            tops = vnstat_data(interface, "t", app.config['NETWORK_INFO_CUTOFF'])['interfaces'][0]['traffic'][qt]
+        top = []
+        for t in tops[:app.config['NETWORK_INFO_TOPSTATS']]:
+            date = t['date']
+            year = date['year']
+            month = calendar.month_abbr[date['month']]
+            day = date['day']
+            date = "{month} {day}, {year}".format(year=year, month=month, day=day)
+            rx = read_unit(t['rx'])
+            tx =read_unit(t['tx'])
+            total = read_unit(t['tx'] + t['rx'])
+            top.append({"date": date, "rx": rx, "tx": tx, "total": total})
+
     columns = {"date", "rx", "tx", "total"}
     #stats = []
     #stats.extend({"statsh": statsh, "statslh": statslh, "statsd": statsd, "statsm": statsm, "statsa": statsa, "top": top})
     #print(stats)
     #return flask.jsonify({"statsh": statsh, "statslh": statslh, "statsd": statsd, "statsm": statsm, "statsa": statsa, "top": top})
-    return flask.render_template('top.html', user=user, timeline=timeline, day=statsd, month=statsm, hour=statsh, lasthour=statslh, alltime=statsa, colnames=columns)
+    return flask.render_template('top.html', user=user, timeline=timeline, day=statsd, month=statsm, hour=statsh, lasthour=statslh, alltime=statsa, colnames=columns, top=top if app.config['NETWORK_INFO_TOP'] else None)
 
 @app.route('/stats/disk')
 @htpasswd.required

--- a/swizzin.py
+++ b/swizzin.py
@@ -323,9 +323,9 @@ def vnstat(user):
     statsm = vnstat_parse(interface, "m", qm, read_unit, thismonth)
     statsa = vnstat_parse(interface, "h", "total", read_unit)
     #statsa = vnstat_parse(interface, "m", "total", 0)
-    tops = vnstat_data(interface, "t")['interfaces'][0]['traffic'][qt]
-    top = []
-    for t in tops[:10]:
+    days = vnstat_data(interface, "d")['interfaces'][0]['traffic'][qd][::-1]
+    timeline = []
+    for t in days[:10]:
         date = t['date']
         year = date['year']
         month = calendar.month_abbr[date['month']]
@@ -334,13 +334,13 @@ def vnstat(user):
         rx = read_unit(t['rx'])
         tx =read_unit(t['tx'])
         total = read_unit(t['tx'] + t['rx'])
-        top.append({"date": date, "rx": rx, "tx": tx, "total": total})
+        timeline.append({"date": date, "rx": rx, "tx": tx, "total": total})
     columns = {"date", "rx", "tx", "total"}
     #stats = []
     #stats.extend({"statsh": statsh, "statslh": statslh, "statsd": statsd, "statsm": statsm, "statsa": statsa, "top": top})
     #print(stats)
     #return flask.jsonify({"statsh": statsh, "statslh": statslh, "statsd": statsd, "statsm": statsm, "statsa": statsa, "top": top})
-    return flask.render_template('top.html', user=user, top=top, day=statsd, month=statsm, hour=statsh, lasthour=statslh, alltime=statsa, colnames=columns)
+    return flask.render_template('top.html', user=user, timeline=timeline, day=statsd, month=statsm, hour=statsh, lasthour=statslh, alltime=statsa, colnames=columns)
 
 @app.route('/stats/disk')
 @htpasswd.required

--- a/templates/netinfo.html
+++ b/templates/netinfo.html
@@ -29,7 +29,7 @@
             <th scope="col">Interface</th>
             <th scope="col" class="text-info text-center">Down</th>
             <th scope="col" class="text-success text-center">Up</th>
-			{% if config.NETWORK_TOTALS == True %}
+			{% if config.NETWORK_INFO_TOTALS == True %}
 			<th scope="col" class="text-warning text-center">Total</th>
 			{% endif %}
         </tr>
@@ -39,7 +39,7 @@
             <td><div id="current_interface">--</div></td>
             <td class="text-info"><div id="current_rx" class="text-center">--</div></td>
             <td class="text-success"><div id="current_tx" class="text-center">--</div></td>
-			{% if config.NETWORK_TOTALS == True %}
+			{% if config.NETWORK_INFO_TOTALS == True %}
 			<td class="text-warning"><div id="current_total" class="text-center">--</div></td>
 			{% endif %}
         </tr>

--- a/templates/top.html
+++ b/templates/top.html
@@ -66,13 +66,13 @@
         </tr>
     </thead>
     <tbody>
-        {% for t in top %}
+        {% for day in timeline %}
         <tr>
-            <td>{{ t['date'] }}</td>
-            <td class="text-info text-center">{{ t['rx'] }}</td>
-            <td class="text-success text-center">{{ t['tx'] }}</td>
-			{% if config.NETWORK_TOTALS == True %}
-			<td class="text-warning text-center">{{ t['total'] }}</td>
+            <td>{{ day['date'] }}</td>
+            <td class="text-info text-center">{{ day['rx'] }}</td>
+            <td class="text-success text-center">{{ day['tx'] }}</td>
+			{% if config.NETWORK_INFO_TOTALS == True %}
+			<td class="text-warning text-center">{{ day['total'] }}</td>
 			{% endif %}
         </tr>
         {% endfor %}

--- a/templates/top.html
+++ b/templates/top.html
@@ -5,7 +5,7 @@
             <th scope="col">Period</th>
             <th scope="col" class="text-info text-center">Down</th>
             <th scope="col" class="text-success text-center">Up</th>
-			{% if config.NETWORK_TOTALS == True %}
+			{% if config.NETWORK_INFO_TOTALS == True %}
 			<th scope="col" class="text-warning text-center">Total</th>
 			{% endif %}
         </tr>
@@ -15,7 +15,7 @@
             <td>This Hour</td>
             <td class="text-info text-right text-center">{{ hour['rx'] }}</td>
             <td class="text-success text-center">{{ hour['tx'] }}</td>
-			{% if config.NETWORK_TOTALS == True %}
+			{% if config.NETWORK_INFO_TOTALS == True %}
 			<td class="text-warning text-center">{{ hour['total'] }}</td>
 			{% endif %}
         </tr>
@@ -23,7 +23,7 @@
             <td>Last Hour</td>
             <td class="text-info text-center">{{ lasthour['rx'] }}</td>
             <td class="text-success text-center">{{ lasthour['tx'] }}</td>
-			{% if config.NETWORK_TOTALS == True %}
+			{% if config.NETWORK_INFO_TOTALS == True %}
 			<td class="text-warning text-center">{{ lasthour['total'] }}</td>
 			{% endif %}
         </tr>
@@ -31,7 +31,7 @@
             <td>This Day</td>
             <td class="text-info text-center">{{ day['rx'] }}</td>
             <td class="text-success text-center">{{ day['tx'] }}</td>
-			{% if config.NETWORK_TOTALS == True %}
+			{% if config.NETWORK_INFO_TOTALS == True %}
 			<td class="text-warning text-center">{{ day['total'] }}</td>
 			{% endif %}
         </tr>
@@ -39,7 +39,7 @@
             <td>This Month</td>
             <td class="text-info text-center">{{ month['rx'] }}</td>
             <td class="text-success text-center">{{ month['tx'] }}</td>
-			{% if config.NETWORK_TOTALS == True %}
+			{% if config.NETWORK_INFO_TOTALS == True %}
 			<td class="text-warning text-center">{{ month['total'] }}</td>
 			{% endif %}
         </tr>
@@ -47,7 +47,7 @@
             <td>All Time</td>
             <td class="text-info text-center">{{ alltime['rx'] }}</td>
             <td class="text-success text-center">{{ alltime['tx'] }}</td>
-			{% if config.NETWORK_TOTALS == True %}
+			{% if config.NETWORK_INFO_TOTALS == True %}
 			<td class="text-warning text-center">{{ alltime['total'] }}</td>
 			{% endif %}
         </tr>
@@ -60,7 +60,7 @@
             <th scope="col">Date</th>
             <th scope="col" class="text-info text-center">Down</th>
             <th scope="col" class="text-success text-center">Up</th>
-			{% if config.NETWORK_TOTALS == True %}
+			{% if config.NETWORK_INFO_TOTALS == True %}
 			<th scope="col" class="text-warning text-center">Total</th>
 			{% endif %}
         </tr>
@@ -78,4 +78,33 @@
         {% endfor %}
     </tbody>
 </table>
+{% if config.NETWORK_INFO_TOP == True %}
+<div class="text-center">
+    <h5>Top Transfer Days</h5>
+</div>
+<table class="table table-condensed table-hover table-dark table-borderless">
+    <thead class="table-active">
+        <tr>
+            <th scope="col">Date</th>
+            <th scope="col" class="text-info text-center">Down</th>
+            <th scope="col" class="text-success text-center">Up</th>
+            {% if config.NETWORK_INFO_TOTALS == True %}
+            <th scope="col" class="text-warning text-center">Total</th>
+            {% endif %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for t in top %}
+        <tr>
+            <td>{{ t['date'] }}</td>
+            <td class="text-info text-center">{{ t['rx'] }}</td>
+            <td class="text-success text-center">{{ t['tx'] }}</td>
+            {% if config.NETWORK_INFO_TOTALS == True %}
+            <td class="text-warning text-center">{{ t['total'] }}</td>
+            {% endif %}
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endif %}
 {% endif %}


### PR DESCRIPTION
These changes will update the functionality of the Network Info widget, on the dashboard.

Changes include:
- Display daily `vnstat` stats in chronological order
- New togglable "Top Days" table underneath (Config > `NETWORK_INFO_TOP = True`)
- Customizable day count in "Top Days" table (Config > `NETWORK_INFO_TOPSTATS = 5`)
- Customizable cut-off (beginning time) in "Top Days" table (Config > `NETWORK_INFO_CUTOFF = "YYYY-MM-DD"`)
- Renaming of `NETWORK_TOTALS` to `NETWORK_INFO_TOTALS`, to better align with new config options
- Defaulting `NETWORK_INFO_TOTALS` to `True`

![swizzin_network_info](https://github.com/user-attachments/assets/a7823d9d-1aae-4ff0-be4f-ea5332c642c6)
