### PR TITLE
Set multiuser flag on Lounge IRC

### DIFF
--- a/core/profiles.py
+++ b/core/profiles.py
@@ -119,6 +119,7 @@ class lounge_meta:
     pretty_name = "The Lounge"
     baseurl = "/irc"
     runas = "lounge"
+    multiuser = True
     
 class mango_meta:
     name = "mango"


### PR DESCRIPTION
Allows secondary users to see the link to Lounge in their panels.

While Lounge is run by a single user (lounge), all users can login. When the multiuser flag is not set, secondary users do not see the link to Lounge in their panels. They can still access the app at `/irc/` and login with their credentials. This change makes the link appear for secondary users.

I have tested this for a while with the following in my custom profiles:

```py
class lounge_meta(lounge_meta):
    multiuser = True
```